### PR TITLE
removed nans

### DIFF
--- a/model.py
+++ b/model.py
@@ -64,7 +64,9 @@ class Encoder(nn.Module):
         self.fc_logvar = nn.Linear(hidden_dim, latent_dim)
         
     def forward(self, x, dropout_rate):
+        epsilon = 1e-10
         norm = x.pow(2).sum(dim=-1).sqrt()
+        norm = norm + epsilon # avoid division by zero
         x = x / norm[:, None]
     
         x = F.dropout(x, p=dropout_rate, training=self.training)


### PR DESCRIPTION
1. Added epsilon in denominator to the normalization in the encoder, because it was throwing nans otherwise.
2. Added check in NDCG calculation to skip users for which there were no interactions present, because then then the IDCG was simply 0, and this would result in nans in the calculation. Ideally, this should be dealt with in preprocessing, but I found this to be an easier fix. If you have a better approach, please let me know as I plan to use this in production for my work.